### PR TITLE
Suppress byte-compile warnings

### DIFF
--- a/shell-toggle.el
+++ b/shell-toggle.el
@@ -86,6 +86,9 @@
 
 (require 'term)
 
+(declare-function ido-get-buffers-in-frames "ido")
+(declare-function eshell-send-input "esh-mode")
+
 (defgroup shell-toggle nil
   "Toggle to and from the shell buffer."
   :group 'shell)


### PR DESCRIPTION
I got following warnings when byte-compiled.

```
In end of data:
shell-toggle.el:339:1:Warning: the following functions are not known to be defined:
    ido-get-buffers-in-frames, eshell-send-input
```
